### PR TITLE
update ros apt key.

### DIFF
--- a/installROS.sh
+++ b/installROS.sh
@@ -87,7 +87,7 @@ sudo apt-add-repository restricted
 # Setup sources.lst
 sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
 # Setup keys
-sudo apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
+sudo apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key F42ED6FBAB17C654 
 # If you experience issues connecting to the keyserver, you can try substituting hkp://pgp.mit.edu:80 or hkp://keyserver.ubuntu.com:80 in the previous command.
 # Installation
 tput setaf 2


### PR DESCRIPTION
Due to the ROS has updated the apt key, the old key can not be used while installing the ROS on the jetson or other ubuntu version. So update the key with the new one.